### PR TITLE
Add mrbgem.rake so this can be used as mrbgem

### DIFF
--- a/bcd.gemspec
+++ b/bcd.gemspec
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require_relative "lib/bcd/version"
+
 Gem::Specification.new do |gem|
   gem.name = "bcd"
-  gem.version = "1.0.6"
+  gem.version = BCD::VERSION
   gem.summary       = "Binary Coded Decimal library"
   gem.description   = "A library for decoding and encoding binary coded decimal"
   gem.author = "David Crosby"

--- a/lib/bcd/version.rb
+++ b/lib/bcd/version.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+module BCD
+  VERSION = "1.0.7"
+end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,0 +1,10 @@
+MRuby::Gem::Specification.new('mruby-bcd') do |gem|
+  gem.summary = "Binary Coded Decimal library"
+  gem.authors = "David Crosby"
+  gem.license = "BSD-2-Clause"
+  gem.version = "1.0.6"
+
+  gem.rbfiles = [
+    "#{dir}/lib/bcd.rb",
+  ]
+end

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,8 +1,10 @@
+require_relative "lib/bcd/version"
+
 MRuby::Gem::Specification.new('ruby_bcd') do |gem|
   gem.summary = "Binary Coded Decimal library"
   gem.authors = "David Crosby"
   gem.license = "BSD-2-Clause"
-  gem.version = "1.0.6"
+  gem.version = BCD::VERSION
 
   gem.rbfiles = [
     "#{dir}/lib/bcd.rb",

--- a/mrbgem.rake
+++ b/mrbgem.rake
@@ -1,4 +1,4 @@
-MRuby::Gem::Specification.new('mruby-bcd') do |gem|
+MRuby::Gem::Specification.new('ruby_bcd') do |gem|
   gem.summary = "Binary Coded Decimal library"
   gem.authors = "David Crosby"
   gem.license = "BSD-2-Clause"


### PR DESCRIPTION
I've been using this on mruby for decoding BCD data from real time clocks. Until now, I've had to add it to one of my mruby gems as a git submodule, then require `{submodule_path}/lib/bcd.rb` in its `mrbgem.rake` (similar to `.gemspec` in Ruby).

Adding an `mrbgem.rake` to this repo makes it usable in any mruby build config with a single line:

`conf.gem :github => 'dafyddcrosby/ruby_bcd'`

and avoids the need to wrap it inside another mruby gem, then require _that_ in the build config.